### PR TITLE
feat: accounts => getAccounts

### DIFF
--- a/src/backend/cyclos/account.ts
+++ b/src/backend/cyclos/account.ts
@@ -2,7 +2,7 @@ import { BridgeObject } from ".."
 
 
 export class CyclosAccount extends BridgeObject {
-
+    type: 'cyclos'
     get balance() {
         return this.jsonData.status.balance
     }

--- a/src/backend/cyclos/index.ts
+++ b/src/backend/cyclos/index.ts
@@ -16,8 +16,8 @@ export abstract class CyclosBackendAbstract extends JsonRESTClientAbstract {
         this.owner_id = accountData.owner_id
     }
 
-
-    get accounts() {
+    accounts: CyclosAccount[]
+    getAccounts() {
         return (async () => {
             let jsonAccounts = await this.$get(`/${this.owner_id}/accounts`)
 
@@ -26,6 +26,7 @@ export abstract class CyclosBackendAbstract extends JsonRESTClientAbstract {
             jsonAccounts.forEach(jsonAccountData => {
                 accounts.push(new CyclosAccount(this, jsonAccountData))
             })
+            this.accounts = accounts
             return accounts
         })()
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,13 @@ abstract class LokAPIAbstract extends OdooRESTAbstract {
         return true
     }
 
+    get accounts() {
+        return this.backends.map(b=>b.accounts).then(r=>r.flat())
+
+    }
+    getAccounts() {
+        return Promise.all(this.backends.map(b=>b.getAccounts())).then(r=>r.flat())
+    }
 }
 
 


### PR DESCRIPTION
* rename to be compliant with other methods signature like `getUserProfile`
* store accounts locally to access them without the need of a new web request
* store the type inside the account object for future accounts type filtering